### PR TITLE
Fix file existence message

### DIFF
--- a/ClsLib/ClsCustomCommands.cs
+++ b/ClsLib/ClsCustomCommands.cs
@@ -160,7 +160,7 @@ namespace ClsLib
 
                 if (File.Exists(fileName))
                 {
-                    result.Add($"File {fileName} already exist.");
+                    result.Add($"File {fileName} already exists.");
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Correct typo in AddFile command's message when a file already exists

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6896098f083c832d9d115b531a2321e4